### PR TITLE
Update logger.rb

### DIFF
--- a/lib/timber/logger.rb
+++ b/lib/timber/logger.rb
@@ -182,8 +182,6 @@ module Timber
 
       self.level = environment_level
 
-      after_initialize if respond_to?(:after_initialize)
-
       Timber::Config.instance.debug { "Timber::Logger instantiated, level: #{level}, formatter: #{formatter.class}" }
 
       @initialized = true


### PR DESCRIPTION
Remove deprecated code to avoid warning:

DEPRECATION WARNING: Logger don't need to call #after_initialize directly anymore. It will be deprecated without replacement in Rails 6.1.